### PR TITLE
[fix] Add missing cron

### DIFF
--- a/conf/cron
+++ b/conf/cron
@@ -1,0 +1,2 @@
+SHELL=/bin/bash
+*/5 * * * * root : Regen named conf; cd __INSTALL_DIR__ && /usr/bin/python3 __INSTALL_DIR__/regen_named_conf.py > /dev/null 2>/dev/null || echo "Regenerating named conf failed"

--- a/scripts/backup
+++ b/scripts/backup
@@ -28,6 +28,7 @@ ynh_backup "/etc/systemd/system/$app-regen-named-conf.service"
 ynh_backup "/etc/systemd/system/$app.service"
 
 ynh_backup "/etc/yunohost/hooks.d/post_iptable_rules/$app-named"
+ynh_backup "/etc/cron.d/$app"
 
 ynh_backup "/etc/logrotate.d/$app"
 

--- a/scripts/install
+++ b/scripts/install
@@ -32,6 +32,7 @@ popd > /dev/null
 
 ynh_config_add --template="config.yml" --destination="$install_dir/dynette/config.yml"
 ynh_config_add --template="gunicorn.py" --destination="$install_dir/dynette/gunicorn.py"
+ynh_config_add --template="cron" --destination="/etc/cron.d/$app"
 
 #=================================================
 # NAMED CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -40,6 +40,7 @@ yunohost service add "$app" --description="Dynette gunicorn daemon" --log="/var/
 
 mkdir -p /etc/yunohost/hooks.d/post_iptable_rules/
 ynh_restore "/etc/yunohost/hooks.d/post_iptable_rules/$app-named"
+ynh_restore "/etc/cron.d/$app"
 
 ynh_restore "/etc/logrotate.d/$app"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -32,6 +32,7 @@ popd > /dev/null
 
 ynh_config_add --template="config.yml" --destination="$install_dir/dynette/config.yml"
 ynh_config_add --template="gunicorn.py" --destination="$install_dir/dynette/gunicorn.py"
+ynh_config_add --template="cron" --destination="/etc/cron.d/$app"
 
 #=================================================
 # NAMED CONFIGURATION


### PR DESCRIPTION
Without this cron file, people get the error "The peer didn't know the key we used" during `yunohost dyndns update`